### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/lib/terrier/doi_data.rb
+++ b/lib/terrier/doi_data.rb
@@ -23,7 +23,7 @@ class Terrier::DoiData
   private
 
   def bibliography
-    self.class.get("http://dx.doi.org/#{doi}", headers: bibliography_header)
+    self.class.get("https://doi.org/#{doi}", headers: bibliography_header)
     .strip
     .force_encoding("utf-8")
     .gsub(/(https?:\/\/[\S]+)/, '<a href="\0">\0</a>')
@@ -33,7 +33,7 @@ class Terrier::DoiData
   end
 
   def doi_citation_info
-    self.class.get("http://dx.doi.org/#{doi}", headers: citation_header, format: :json)
+    self.class.get("https://doi.org/#{doi}", headers: citation_header, format: :json)
   end
 
   def bibliography_header

--- a/spec/doi_data_spec.rb
+++ b/spec/doi_data_spec.rb
@@ -17,11 +17,11 @@ describe Terrier::DoiData do
     end
 
     it "returns a collection containing the journal name" do
-      expect(Terrier::DoiData.new('doi:10.1186/1479-5868-10-79').data[:journal]).to eq('Int J Behav Nutr Phys Act')
+      expect(Terrier::DoiData.new('doi:10.1186/1479-5868-10-79').data[:journal]).to eq('International Journal of Behavioral Nutrition and Physical Activity')
     end
 
     it "returns a collection containing the journal publisher" do
-      expect(Terrier::DoiData.new('doi:10.1186/1479-5868-10-79').data[:publisher]).to eq('Springer Science + Business Media')
+      expect(Terrier::DoiData.new('doi:10.1186/1479-5868-10-79').data[:publisher]).to eq('Springer Nature')
     end
 
     it "returns a collection containing the journal title" do

--- a/spec/doi_data_spec.rb
+++ b/spec/doi_data_spec.rb
@@ -13,7 +13,7 @@ describe Terrier::DoiData do
   describe 'data' do
     use_vcr_cassette
     it "returns a collection containing the a url" do
-      expect(Terrier::DoiData.new('doi:10.1186/1479-5868-10-79').data[:url]).to eq('http://dx.doi.org/10.1186/1479-5868-10-79')
+      expect(Terrier::DoiData.new('doi:10.1186/1479-5868-10-79').data[:url]).to eq('https://doi.org/10.1186/1479-5868-10-79')
     end
 
     it "returns a collection containing the journal name" do

--- a/spec/doi_data_spec.rb
+++ b/spec/doi_data_spec.rb
@@ -13,7 +13,7 @@ describe Terrier::DoiData do
   describe 'data' do
     use_vcr_cassette
     it "returns a collection containing the a url" do
-      expect(Terrier::DoiData.new('doi:10.1186/1479-5868-10-79').data[:url]).to eq('https://doi.org/10.1186/1479-5868-10-79')
+      expect(Terrier::DoiData.new('doi:10.1186/1479-5868-10-79').data[:url]).to eq('http://dx.doi.org/10.1186/1479-5868-10-79')
     end
 
     it "returns a collection containing the journal name" do

--- a/spec/terrier_spec.rb
+++ b/spec/terrier_spec.rb
@@ -67,7 +67,7 @@ describe Terrier do
         allow_any_instance_of(Terrier::HtmlData).to receive(:data).and_return(http_data)
 
         doi_data = {
-          url: "http://dx.doi.org/10.15200/winn.140832.20404",
+          url: "https://doi.org/10.15200/winn.140832.20404",
           issn: ["2373-146X"],
           journal: "The Winnower, LLC",
           publication_year: 2014,


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update any code that generates new DOI links, plus its tests.

Cheers!